### PR TITLE
Update to permit `user_id`

### DIFF
--- a/app/controllers/api/v1/notes_controller.rb
+++ b/app/controllers/api/v1/notes_controller.rb
@@ -28,7 +28,7 @@ class Api::V1::NotesController < ApplicationController
 
   private
   def note_params
-    params.permit(:body, :title)
+    params.permit(:body, :title, :user_id)
   end
 
   def set_note


### PR DESCRIPTION
In order for students to pass in a `user_id` whenever we make a `POST http://localhost:3000/api/v1/notes`, we need to add this into the permitted params. 

So whenever a student passes in a JSON of `{ "title": "test-title", "body": "test-body", "user_id": "YOUR_USER_ID"}`, the association can be made. Since the `models/notes.rb` has an optional parameter, it is okay to be omitted for the rest of the example to work. However, if they want to implement the user association, the need to pass in the `user_id` since we are using strong parameters.